### PR TITLE
Fix filter element name

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -72,7 +72,7 @@ app.post('/token', (req, res) => {
 
 app.post('/logout', (req, res) => {
     const { token } = req.body;
-    refreshTokens = refreshTokens.filter(token => t !== token);
+    refreshTokens = refreshTokens.filter(token => token !== token);
 
     res.send("Logout successful");
 });


### PR DESCRIPTION
>ReferenceError: t is not defined

Changing
`refreshTokens = refreshTokens.filter(token => t !== token);`
to
`refreshTokens = refreshTokens.filter(token => token !== token);`
solves this issue.